### PR TITLE
Add Cratecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Translations:
 | [Replicate](http://replicate.com) | Machine Learning DoesnT Need to Be So Hard. | Run open-source models with a cloud API. | :white_check_mark: |
 | [Speakingclubai](http://speakingclubai.com) | Speaking Club AI. | Welcome to Speaking Club AI - the ultimate language learning tool for anyone looking to improve their speaking skills in a foreign language. With Speaking Club AI, you can practice    your conversation skills with a personalized AI language partner anytime, anywhere. | :grey_question: |
 | [teachology.ai](https://www.teachology.ai/) | A Collection of Tools for Teachers and Educators to Harness the Power of AI in Their Pedagogy and Planning. | Plan Lessons - Harness AI to draft your lessons and export to your favourite formats. Build Rich Assessments - Construct rich assessments with robust rubric driven marking criteria. And more. | :white_check_mark: |
+| [Cratecode](https://cratecode.com/) | Cratecode - Learn to Code for Free | Learn to code through online lessons and a powerful AI assistant! The assistant can analyze your code, nudge you in the right direction, and write help articles for simple topics. | :white_check_mark: |
 
 <!--End of Education & Learning 32-->
 


### PR DESCRIPTION
Cratecode uses GPT-4 to provide a programming assistant and to automatically generate help articles. Both are free (although a signup is required). Here's some demo links:
* https://cratecode.com/info/javascript-create-element - AI generated help article.
* https://www.youtube.com/watch?v=gbn058nB1FM - Programming assistant demo.

I considered putting this under `Coding Assistant`, but I feel that it's more geared towards helping you write production code than learning how to program--which is what this one does. Please let me know if a different category would fit better!