### PR TITLE
Add DoaCam to Chat Bot category

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,6 +999,22 @@ DreamPal is a chatbot blending AI chat with immersive roleplay. Users can intera
 <br />
 
 
+### DoaCam
+<img align="left" width="240" src="https://cdn.thataicollection.com/screenshots/screenshot-doacam.webp" alt="DoaCam">
+
+#### A 3D AI Avatar You Can Video Call in the Browser
+
+
+[Visit](https://doacam.com)
+
+DoaCam is a 3D AI avatar you can video call in the browser. Real-time voice, camera vision, 97 facial expressions, and persistent memory. Free, no sign-up required.
+
+
+[More Information and Pricing](https://doacam.com)
+
+<br />
+
+
 [See All 🤖💬 Chat Bot Applications on AI Collection](https://thataicollection.com/en/categories/chat-bot?utm_source=aicollection&utm_medium=github&utm_campaign=aicollection)
 
 <!--lint ignore double-link-->


### PR DESCRIPTION
Adds DoaCam to the Chat Bot category. DoaCam is a 3D AI avatar you can video call in the browser with real-time voice, camera vision, 97 facial expressions, and persistent memory. Free, no sign-up required. Website: https://doacam.com