### PR TITLE
Add Onepilot to Code & Database Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,22 @@ JustCopy.ai lets anyone go from idea to live website in minutes. Copy any existi
 <br />
 
 
+
+
+### Onepilot
+
+#### Mobile terminal + AI agent IDE for iOS
+
+
+[Visit](https://onepilotapp.com)
+
+Onepilot is an iOS app that SSHes into remote servers so you can run Claude Code, Codex, and other CLI coding tools from your phone. It's a full mobile terminal with a dev IDE layer — GitHub, localhost forwarding, file editing — plus one-click AI agent deployment via OpenClaw.
+
+
+[More Information and Pricing](https://onepilotapp.com)
+
+<br />
+
 [See All 💻 Code & Database Assistant Applications on AI Collection](https://thataicollection.com/en/categories/code-and-database-assistant?utm_source=aicollection&utm_medium=github&utm_campaign=aicollection)
 
 <!--lint ignore double-link-->


### PR DESCRIPTION
Adds Onepilot to the Code & Database Assistant section.

Onepilot is an iOS app that SSHes into remote servers so you can run Claude Code, Codex, and other CLI coding tools from your phone. It's a full mobile terminal with a dev IDE layer (GitHub, localhost forwarding, file editing) plus one-click AI agent deployment via OpenClaw.

Website: https://onepilotapp.com