### PR TITLE
Add MeterCall (zapier-killer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5497,3 +5497,4 @@ Smodin provides all-in-one writing essentials. Writing and homework assistance p
 
 ---
 
+- [MeterCall](https://metercall.ai/?v=c&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** Zapier has 7,000 apps. MeterCall has 21,000,000 APIs. One bill. Metered by the call.
- **URL:** https://metercall.ai/?v=c&src=github
- **Why it belongs here:** The Generative AI Landscape - A Collection of Awesome Generative AI Applications

Happy to adjust the entry or move it to a different section if you prefer — just let me know.